### PR TITLE
Port CPython 3.6.5 test cases

### DIFF
--- a/tests/cpython/__init__.py
+++ b/tests/cpython/__init__.py
@@ -1,0 +1,56 @@
+import os
+import json
+import doctest
+import unittest
+
+from test import support
+
+# import json with and without accelerations
+cjson = support.import_fresh_module('json', fresh=['_json'])
+pyjson = support.import_fresh_module('json', blocked=['_json'])
+# JSONDecodeError is cached inside the _json module
+cjson.JSONDecodeError = cjson.decoder.JSONDecodeError = json.JSONDecodeError
+
+# create two base classes that will be used by the other tests
+class PyTest(unittest.TestCase):
+    json = pyjson
+    loads = staticmethod(pyjson.loads)
+    dumps = staticmethod(pyjson.dumps)
+    JSONDecodeError = staticmethod(pyjson.JSONDecodeError)
+
+@unittest.skipUnless(cjson, 'requires _json')
+class CTest(unittest.TestCase):
+    if cjson is not None:
+        json = cjson
+        loads = staticmethod(cjson.loads)
+        dumps = staticmethod(cjson.dumps)
+        JSONDecodeError = staticmethod(cjson.JSONDecodeError)
+
+# test PyTest and CTest checking if the functions come from the right module
+class TestPyTest(PyTest):
+    def test_pyjson(self):
+        self.assertEqual(self.json.scanner.make_scanner.__module__,
+                         'json.scanner')
+        self.assertEqual(self.json.decoder.scanstring.__module__,
+                         'json.decoder')
+        self.assertEqual(self.json.encoder.encode_basestring_ascii.__module__,
+                         'json.encoder')
+
+class TestCTest(CTest):
+    def test_cjson(self):
+        self.assertEqual(self.json.scanner.make_scanner.__module__, '_json')
+        self.assertEqual(self.json.decoder.scanstring.__module__, '_json')
+        self.assertEqual(self.json.encoder.c_make_encoder.__module__, '_json')
+        self.assertEqual(self.json.encoder.encode_basestring_ascii.__module__,
+                         '_json')
+
+
+def load_tests(loader, _, pattern):
+    suite = unittest.TestSuite()
+    for mod in (json, json.encoder, json.decoder):
+        suite.addTest(doctest.DocTestSuite(mod))
+    suite.addTest(TestPyTest('test_pyjson'))
+    suite.addTest(TestCTest('test_cjson'))
+
+    pkg_dir = os.path.dirname(__file__)
+    return support.load_package_tests(pkg_dir, loader, suite, pattern)

--- a/tests/cpython/__init__.py
+++ b/tests/cpython/__init__.py
@@ -8,6 +8,7 @@ from test import support
 # import json with and without accelerations
 cjson = support.import_fresh_module('json', fresh=['_json'])
 pyjson = support.import_fresh_module('json', blocked=['_json'])
+hyperjson = support.import_fresh_module('hyperjson')
 # JSONDecodeError is cached inside the _json module
 cjson.JSONDecodeError = cjson.decoder.JSONDecodeError = json.JSONDecodeError
 
@@ -26,6 +27,16 @@ class CTest(unittest.TestCase):
         dumps = staticmethod(cjson.dumps)
         JSONDecodeError = staticmethod(cjson.JSONDecodeError)
 
+@unittest.skipUnless(hyperjson, 'requires hyperjson')
+class RustTest(unittest.TestCase):
+    if hyperjson is not None:
+        json = hyperjson
+        loads = staticmethod(hyperjson.loads)
+        dumps = staticmethod(hyperjson.dumps)
+        # FIXME: WTF
+        JSONDecodeError = staticmethod(pyjson.JSONDecodeError)
+        # JSONDecodeError = staticmethod(hyperjson.JSONDecodeError)
+
 # test PyTest and CTest checking if the functions come from the right module
 class TestPyTest(PyTest):
     def test_pyjson(self):
@@ -43,6 +54,16 @@ class TestCTest(CTest):
         self.assertEqual(self.json.encoder.c_make_encoder.__module__, '_json')
         self.assertEqual(self.json.encoder.encode_basestring_ascii.__module__,
                          '_json')
+
+class TestRustTest(RustTest):
+    def test_hyperjson(self):
+        # FIXME:
+        pass
+        # self.assertEqual(self.json.scanner.make_scanner.__module__, 'hyperjson')
+        # self.assertEqual(self.json.decoder.scanstring.__module__, 'hyperjson')
+        # self.assertEqual(self.json.encoder.c_make_encoder.__module__, 'hyperjson')
+        # self.assertEqual(self.json.encoder.encode_basestring_ascii.__module__,
+        #                  'hyperjson')
 
 
 def load_tests(loader, _, pattern):

--- a/tests/cpython/__init__.py
+++ b/tests/cpython/__init__.py
@@ -33,7 +33,7 @@ class RustTest(unittest.TestCase):
         json = hyperjson
         loads = staticmethod(hyperjson.loads)
         dumps = staticmethod(hyperjson.dumps)
-        # FIXME: WTF
+        # FIXME: hyperjson does not have this
         JSONDecodeError = staticmethod(pyjson.JSONDecodeError)
         # JSONDecodeError = staticmethod(hyperjson.JSONDecodeError)
 
@@ -57,7 +57,7 @@ class TestCTest(CTest):
 
 class TestRustTest(RustTest):
     def test_hyperjson(self):
-        # FIXME:
+        # FIXME: hyperjson does not have any of this
         pass
         # self.assertEqual(self.json.scanner.make_scanner.__module__, 'hyperjson')
         # self.assertEqual(self.json.decoder.scanstring.__module__, 'hyperjson')

--- a/tests/cpython/__main__.py
+++ b/tests/cpython/__main__.py
@@ -1,0 +1,4 @@
+import unittest
+from test.test_json import load_tests
+
+unittest.main()

--- a/tests/cpython/__main__.py
+++ b/tests/cpython/__main__.py
@@ -1,4 +1,4 @@
 import unittest
-from test.test_json import load_tests
+from cpython import load_tests
 
 unittest.main()

--- a/tests/cpython/test_decode.py
+++ b/tests/cpython/test_decode.py
@@ -1,0 +1,97 @@
+import decimal
+from io import StringIO, BytesIO
+from collections import OrderedDict
+from test.test_json import PyTest, CTest
+
+
+class TestDecode:
+    def test_decimal(self):
+        rval = self.loads('1.1', parse_float=decimal.Decimal)
+        self.assertTrue(isinstance(rval, decimal.Decimal))
+        self.assertEqual(rval, decimal.Decimal('1.1'))
+
+    def test_float(self):
+        rval = self.loads('1', parse_int=float)
+        self.assertTrue(isinstance(rval, float))
+        self.assertEqual(rval, 1.0)
+
+    def test_empty_objects(self):
+        self.assertEqual(self.loads('{}'), {})
+        self.assertEqual(self.loads('[]'), [])
+        self.assertEqual(self.loads('""'), "")
+
+    def test_object_pairs_hook(self):
+        s = '{"xkd":1, "kcw":2, "art":3, "hxm":4, "qrt":5, "pad":6, "hoy":7}'
+        p = [("xkd", 1), ("kcw", 2), ("art", 3), ("hxm", 4),
+             ("qrt", 5), ("pad", 6), ("hoy", 7)]
+        self.assertEqual(self.loads(s), eval(s))
+        self.assertEqual(self.loads(s, object_pairs_hook=lambda x: x), p)
+        self.assertEqual(self.json.load(StringIO(s),
+                                        object_pairs_hook=lambda x: x), p)
+        od = self.loads(s, object_pairs_hook=OrderedDict)
+        self.assertEqual(od, OrderedDict(p))
+        self.assertEqual(type(od), OrderedDict)
+        # the object_pairs_hook takes priority over the object_hook
+        self.assertEqual(self.loads(s, object_pairs_hook=OrderedDict,
+                                    object_hook=lambda x: None),
+                         OrderedDict(p))
+        # check that empty object literals work (see #17368)
+        self.assertEqual(self.loads('{}', object_pairs_hook=OrderedDict),
+                         OrderedDict())
+        self.assertEqual(self.loads('{"empty": {}}',
+                                    object_pairs_hook=OrderedDict),
+                         OrderedDict([('empty', OrderedDict())]))
+
+    def test_decoder_optimizations(self):
+        # Several optimizations were made that skip over calls to
+        # the whitespace regex, so this test is designed to try and
+        # exercise the uncommon cases. The array cases are already covered.
+        rval = self.loads('{   "key"    :    "value"    ,  "k":"v"    }')
+        self.assertEqual(rval, {"key":"value", "k":"v"})
+
+    def check_keys_reuse(self, source, loads):
+        rval = loads(source)
+        (a, b), (c, d) = sorted(rval[0]), sorted(rval[1])
+        self.assertIs(a, c)
+        self.assertIs(b, d)
+
+    def test_keys_reuse(self):
+        s = '[{"a_key": 1, "b_\xe9": 2}, {"a_key": 3, "b_\xe9": 4}]'
+        self.check_keys_reuse(s, self.loads)
+        self.check_keys_reuse(s, self.json.decoder.JSONDecoder().decode)
+
+    def test_extra_data(self):
+        s = '[1, 2, 3]5'
+        msg = 'Extra data'
+        self.assertRaisesRegex(self.JSONDecodeError, msg, self.loads, s)
+
+    def test_invalid_escape(self):
+        s = '["abc\\y"]'
+        msg = 'escape'
+        self.assertRaisesRegex(self.JSONDecodeError, msg, self.loads, s)
+
+    def test_invalid_input_type(self):
+        msg = 'the JSON object must be str'
+        for value in [1, 3.14, [], {}, None]:
+            self.assertRaisesRegex(TypeError, msg, self.loads, value)
+
+    def test_string_with_utf8_bom(self):
+        # see #18958
+        bom_json = "[1,2,3]".encode('utf-8-sig').decode('utf-8')
+        with self.assertRaises(self.JSONDecodeError) as cm:
+            self.loads(bom_json)
+        self.assertIn('BOM', str(cm.exception))
+        with self.assertRaises(self.JSONDecodeError) as cm:
+            self.json.load(StringIO(bom_json))
+        self.assertIn('BOM', str(cm.exception))
+        # make sure that the BOM is not detected in the middle of a string
+        bom_in_str = '"{}"'.format(''.encode('utf-8-sig').decode('utf-8'))
+        self.assertEqual(self.loads(bom_in_str), '\ufeff')
+        self.assertEqual(self.json.load(StringIO(bom_in_str)), '\ufeff')
+
+    def test_negative_index(self):
+        d = self.json.JSONDecoder()
+        self.assertRaises(ValueError, d.raw_decode, 'a'*42, -50000)
+
+class TestPyDecode(TestDecode, PyTest): pass
+class TestCDecode(TestDecode, CTest): pass

--- a/tests/cpython/test_decode.py
+++ b/tests/cpython/test_decode.py
@@ -93,6 +93,6 @@ class _TestDecode:
         d = self.json.JSONDecoder()
         self.assertRaises(ValueError, d.raw_decode, 'a'*42, -50000)
 
-class TestPyDecode(_TestDecode, PyTest): pass
-class TestCDecode(_TestDecode, CTest): pass
+# class TestPyDecode(_TestDecode, PyTest): pass
+# class TestCDecode(_TestDecode, CTest): pass
 class TestRustDecode(_TestDecode, RustTest): pass

--- a/tests/cpython/test_decode.py
+++ b/tests/cpython/test_decode.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from test.test_json import PyTest, CTest
 
 
-class TestDecode:
+class _TestDecode:
     def test_decimal(self):
         rval = self.loads('1.1', parse_float=decimal.Decimal)
         self.assertTrue(isinstance(rval, decimal.Decimal))
@@ -93,5 +93,5 @@ class TestDecode:
         d = self.json.JSONDecoder()
         self.assertRaises(ValueError, d.raw_decode, 'a'*42, -50000)
 
-class TestPyDecode(TestDecode, PyTest): pass
-class TestCDecode(TestDecode, CTest): pass
+class TestPyDecode(_TestDecode, PyTest): pass
+class TestCDecode(_TestDecode, CTest): pass

--- a/tests/cpython/test_decode.py
+++ b/tests/cpython/test_decode.py
@@ -1,7 +1,7 @@
 import decimal
 from io import StringIO, BytesIO
 from collections import OrderedDict
-from test.test_json import PyTest, CTest
+from cpython import PyTest, CTest, RustTest
 
 
 class _TestDecode:
@@ -95,3 +95,4 @@ class _TestDecode:
 
 class TestPyDecode(_TestDecode, PyTest): pass
 class TestCDecode(_TestDecode, CTest): pass
+class TestRustDecode(_TestDecode, RustTest): pass

--- a/tests/cpython/test_default.py
+++ b/tests/cpython/test_default.py
@@ -1,0 +1,12 @@
+from test.test_json import PyTest, CTest
+
+
+class TestDefault:
+    def test_default(self):
+        self.assertEqual(
+            self.dumps(type, default=repr),
+            self.dumps(repr(type)))
+
+
+class TestPyDefault(TestDefault, PyTest): pass
+class TestCDefault(TestDefault, CTest): pass

--- a/tests/cpython/test_default.py
+++ b/tests/cpython/test_default.py
@@ -8,6 +8,6 @@ class _TestDefault:
             self.dumps(repr(type)))
 
 
-class TestPyDefault(_TestDefault, PyTest): pass
-class TestCDefault(_TestDefault, CTest): pass
+# class TestPyDefault(_TestDefault, PyTest): pass
+# class TestCDefault(_TestDefault, CTest): pass
 class TestRustDefault(_TestDefault, RustTest): pass

--- a/tests/cpython/test_default.py
+++ b/tests/cpython/test_default.py
@@ -1,12 +1,12 @@
 from test.test_json import PyTest, CTest
 
 
-class TestDefault:
+class _TestDefault:
     def test_default(self):
         self.assertEqual(
             self.dumps(type, default=repr),
             self.dumps(repr(type)))
 
 
-class TestPyDefault(TestDefault, PyTest): pass
-class TestCDefault(TestDefault, CTest): pass
+class TestPyDefault(_TestDefault, PyTest): pass
+class TestCDefault(_TestDefault, CTest): pass

--- a/tests/cpython/test_default.py
+++ b/tests/cpython/test_default.py
@@ -1,4 +1,4 @@
-from test.test_json import PyTest, CTest
+from cpython import PyTest, CTest, RustTest
 
 
 class _TestDefault:
@@ -10,3 +10,4 @@ class _TestDefault:
 
 class TestPyDefault(_TestDefault, PyTest): pass
 class TestCDefault(_TestDefault, CTest): pass
+class TestRustDefault(_TestDefault, RustTest): pass

--- a/tests/cpython/test_dump.py
+++ b/tests/cpython/test_dump.py
@@ -1,0 +1,68 @@
+from io import StringIO
+from test.test_json import PyTest, CTest
+
+from test.support import bigmemtest, _1G
+
+class TestDump:
+    def test_dump(self):
+        sio = StringIO()
+        self.json.dump({}, sio)
+        self.assertEqual(sio.getvalue(), '{}')
+
+    def test_dumps(self):
+        self.assertEqual(self.dumps({}), '{}')
+
+    def test_encode_truefalse(self):
+        self.assertEqual(self.dumps(
+                 {True: False, False: True}, sort_keys=True),
+                 '{"false": true, "true": false}')
+        self.assertEqual(self.dumps(
+                {2: 3.0, 4.0: 5, False: 1, 6: True}, sort_keys=True),
+                '{"false": 1, "2": 3.0, "4.0": 5, "6": true}')
+
+    # Issue 16228: Crash on encoding resized list
+    def test_encode_mutated(self):
+        a = [object()] * 10
+        def crasher(obj):
+            del a[-1]
+        self.assertEqual(self.dumps(a, default=crasher),
+                 '[null, null, null, null, null]')
+
+    # Issue 24094
+    def test_encode_evil_dict(self):
+        class D(dict):
+            def keys(self):
+                return L
+
+        class X:
+            def __hash__(self):
+                del L[0]
+                return 1337
+
+            def __lt__(self, o):
+                return 0
+
+        L = [X() for i in range(1122)]
+        d = D()
+        d[1337] = "true.dat"
+        self.assertEqual(self.dumps(d, sort_keys=True), '{"1337": "true.dat"}')
+
+
+class TestPyDump(TestDump, PyTest): pass
+
+class TestCDump(TestDump, CTest):
+
+    # The size requirement here is hopefully over-estimated (actual
+    # memory consumption depending on implementation details, and also
+    # system memory management, since this may allocate a lot of
+    # small objects).
+
+    @bigmemtest(size=_1G, memuse=1)
+    def test_large_list(self, size):
+        N = int(30 * 1024 * 1024 * (size / _1G))
+        l = [1] * N
+        encoded = self.dumps(l)
+        self.assertEqual(len(encoded), N * 3)
+        self.assertEqual(encoded[:1], "[")
+        self.assertEqual(encoded[-2:], "1]")
+        self.assertEqual(encoded[1:-2], "1, " * (N - 1))

--- a/tests/cpython/test_dump.py
+++ b/tests/cpython/test_dump.py
@@ -1,5 +1,5 @@
 from io import StringIO
-from test.test_json import PyTest, CTest
+from cpython import PyTest, CTest, RustTest
 
 from test.support import bigmemtest, _1G
 
@@ -66,3 +66,5 @@ class TestCDump(_TestDump, CTest):
         self.assertEqual(encoded[:1], "[")
         self.assertEqual(encoded[-2:], "1]")
         self.assertEqual(encoded[1:-2], "1, " * (N - 1))
+
+class TestRustDump(_TestDump, RustTest): pass

--- a/tests/cpython/test_dump.py
+++ b/tests/cpython/test_dump.py
@@ -48,23 +48,23 @@ class _TestDump:
         self.assertEqual(self.dumps(d, sort_keys=True), '{"1337": "true.dat"}')
 
 
-class TestPyDump(_TestDump, PyTest): pass
+# class TestPyDump(_TestDump, PyTest): pass
 
-class TestCDump(_TestDump, CTest):
+# class TestCDump(_TestDump, CTest):
 
-    # The size requirement here is hopefully over-estimated (actual
-    # memory consumption depending on implementation details, and also
-    # system memory management, since this may allocate a lot of
-    # small objects).
+#     # The size requirement here is hopefully over-estimated (actual
+#     # memory consumption depending on implementation details, and also
+#     # system memory management, since this may allocate a lot of
+#     # small objects).
 
-    @bigmemtest(size=_1G, memuse=1)
-    def test_large_list(self, size):
-        N = int(30 * 1024 * 1024 * (size / _1G))
-        l = [1] * N
-        encoded = self.dumps(l)
-        self.assertEqual(len(encoded), N * 3)
-        self.assertEqual(encoded[:1], "[")
-        self.assertEqual(encoded[-2:], "1]")
-        self.assertEqual(encoded[1:-2], "1, " * (N - 1))
+#     @bigmemtest(size=_1G, memuse=1)
+#     def test_large_list(self, size):
+#         N = int(30 * 1024 * 1024 * (size / _1G))
+#         l = [1] * N
+#         encoded = self.dumps(l)
+#         self.assertEqual(len(encoded), N * 3)
+#         self.assertEqual(encoded[:1], "[")
+#         self.assertEqual(encoded[-2:], "1]")
+#         self.assertEqual(encoded[1:-2], "1, " * (N - 1))
 
 class TestRustDump(_TestDump, RustTest): pass

--- a/tests/cpython/test_dump.py
+++ b/tests/cpython/test_dump.py
@@ -3,7 +3,7 @@ from test.test_json import PyTest, CTest
 
 from test.support import bigmemtest, _1G
 
-class TestDump:
+class _TestDump:
     def test_dump(self):
         sio = StringIO()
         self.json.dump({}, sio)
@@ -48,9 +48,9 @@ class TestDump:
         self.assertEqual(self.dumps(d, sort_keys=True), '{"1337": "true.dat"}')
 
 
-class TestPyDump(TestDump, PyTest): pass
+class TestPyDump(_TestDump, PyTest): pass
 
-class TestCDump(TestDump, CTest):
+class TestCDump(_TestDump, CTest):
 
     # The size requirement here is hopefully over-estimated (actual
     # memory consumption depending on implementation details, and also

--- a/tests/cpython/test_encode_basestring_ascii.py
+++ b/tests/cpython/test_encode_basestring_ascii.py
@@ -1,0 +1,48 @@
+from collections import OrderedDict
+from test.test_json import PyTest, CTest
+from test.support import bigaddrspacetest
+
+
+CASES = [
+    ('/\\"\ucafe\ubabe\uab98\ufcde\ubcda\uef4a\x08\x0c\n\r\t`1~!@#$%^&*()_+-=[]{}|;:\',./<>?', '"/\\\\\\"\\ucafe\\ubabe\\uab98\\ufcde\\ubcda\\uef4a\\b\\f\\n\\r\\t`1~!@#$%^&*()_+-=[]{}|;:\',./<>?"'),
+    ('\u0123\u4567\u89ab\ucdef\uabcd\uef4a', '"\\u0123\\u4567\\u89ab\\ucdef\\uabcd\\uef4a"'),
+    ('controls', '"controls"'),
+    ('\x08\x0c\n\r\t', '"\\b\\f\\n\\r\\t"'),
+    ('{"object with 1 member":["array with 1 element"]}', '"{\\"object with 1 member\\":[\\"array with 1 element\\"]}"'),
+    (' s p a c e d ', '" s p a c e d "'),
+    ('\U0001d120', '"\\ud834\\udd20"'),
+    ('\u03b1\u03a9', '"\\u03b1\\u03a9"'),
+    ("`1~!@#$%^&*()_+-={':[,]}|;.</>?", '"`1~!@#$%^&*()_+-={\':[,]}|;.</>?"'),
+    ('\x08\x0c\n\r\t', '"\\b\\f\\n\\r\\t"'),
+    ('\u0123\u4567\u89ab\ucdef\uabcd\uef4a', '"\\u0123\\u4567\\u89ab\\ucdef\\uabcd\\uef4a"'),
+]
+
+class TestEncodeBasestringAscii:
+    def test_encode_basestring_ascii(self):
+        fname = self.json.encoder.encode_basestring_ascii.__name__
+        for input_string, expect in CASES:
+            result = self.json.encoder.encode_basestring_ascii(input_string)
+            self.assertEqual(result, expect,
+                '{0!r} != {1!r} for {2}({3!r})'.format(
+                    result, expect, fname, input_string))
+
+    def test_ordered_dict(self):
+        # See issue 6105
+        items = [('one', 1), ('two', 2), ('three', 3), ('four', 4), ('five', 5)]
+        s = self.dumps(OrderedDict(items))
+        self.assertEqual(s, '{"one": 1, "two": 2, "three": 3, "four": 4, "five": 5}')
+
+    def test_sorted_dict(self):
+        items = [('one', 1), ('two', 2), ('three', 3), ('four', 4), ('five', 5)]
+        s = self.dumps(dict(items), sort_keys=True)
+        self.assertEqual(s, '{"five": 5, "four": 4, "one": 1, "three": 3, "two": 2}')
+
+
+class TestPyEncodeBasestringAscii(TestEncodeBasestringAscii, PyTest): pass
+class TestCEncodeBasestringAscii(TestEncodeBasestringAscii, CTest):
+    @bigaddrspacetest
+    def test_overflow(self):
+        size = (2**32)//6 + 1
+        s = "\x00"*size
+        with self.assertRaises(OverflowError):
+            self.json.encoder.encode_basestring_ascii(s)

--- a/tests/cpython/test_encode_basestring_ascii.py
+++ b/tests/cpython/test_encode_basestring_ascii.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from test.test_json import PyTest, CTest
+from cpython import PyTest, CTest, RustTest
 from test.support import bigaddrspacetest
 
 
@@ -46,3 +46,5 @@ class TestCEncodeBasestringAscii(_TestEncodeBasestringAscii, CTest):
         s = "\x00"*size
         with self.assertRaises(OverflowError):
             self.json.encoder.encode_basestring_ascii(s)
+
+class TestRustEncodeBasestringAscii(_TestEncodeBasestringAscii, RustTest): pass

--- a/tests/cpython/test_encode_basestring_ascii.py
+++ b/tests/cpython/test_encode_basestring_ascii.py
@@ -38,13 +38,13 @@ class _TestEncodeBasestringAscii:
         self.assertEqual(s, '{"five": 5, "four": 4, "one": 1, "three": 3, "two": 2}')
 
 
-class TestPyEncodeBasestringAscii(_TestEncodeBasestringAscii, PyTest): pass
-class TestCEncodeBasestringAscii(_TestEncodeBasestringAscii, CTest):
-    @bigaddrspacetest
-    def test_overflow(self):
-        size = (2**32)//6 + 1
-        s = "\x00"*size
-        with self.assertRaises(OverflowError):
-            self.json.encoder.encode_basestring_ascii(s)
+# class TestPyEncodeBasestringAscii(_TestEncodeBasestringAscii, PyTest): pass
+# class TestCEncodeBasestringAscii(_TestEncodeBasestringAscii, CTest):
+#     @bigaddrspacetest
+#     def test_overflow(self):
+#         size = (2**32)//6 + 1
+#         s = "\x00"*size
+#         with self.assertRaises(OverflowError):
+#             self.json.encoder.encode_basestring_ascii(s)
 
 class TestRustEncodeBasestringAscii(_TestEncodeBasestringAscii, RustTest): pass

--- a/tests/cpython/test_encode_basestring_ascii.py
+++ b/tests/cpython/test_encode_basestring_ascii.py
@@ -17,7 +17,7 @@ CASES = [
     ('\u0123\u4567\u89ab\ucdef\uabcd\uef4a', '"\\u0123\\u4567\\u89ab\\ucdef\\uabcd\\uef4a"'),
 ]
 
-class TestEncodeBasestringAscii:
+class _TestEncodeBasestringAscii:
     def test_encode_basestring_ascii(self):
         fname = self.json.encoder.encode_basestring_ascii.__name__
         for input_string, expect in CASES:
@@ -38,8 +38,8 @@ class TestEncodeBasestringAscii:
         self.assertEqual(s, '{"five": 5, "four": 4, "one": 1, "three": 3, "two": 2}')
 
 
-class TestPyEncodeBasestringAscii(TestEncodeBasestringAscii, PyTest): pass
-class TestCEncodeBasestringAscii(TestEncodeBasestringAscii, CTest):
+class TestPyEncodeBasestringAscii(_TestEncodeBasestringAscii, PyTest): pass
+class TestCEncodeBasestringAscii(_TestEncodeBasestringAscii, CTest):
     @bigaddrspacetest
     def test_overflow(self):
         size = (2**32)//6 + 1

--- a/tests/cpython/test_enum.py
+++ b/tests/cpython/test_enum.py
@@ -1,0 +1,120 @@
+from enum import Enum, IntEnum
+from math import isnan
+from test.test_json import PyTest, CTest
+
+SMALL = 1
+BIG = 1<<32
+HUGE = 1<<64
+REALLY_HUGE = 1<<96
+
+class BigNum(IntEnum):
+    small = SMALL
+    big = BIG
+    huge = HUGE
+    really_huge = REALLY_HUGE
+
+E = 2.718281
+PI = 3.141593
+TAU = 2 * PI
+
+class FloatNum(float, Enum):
+    e = E
+    pi = PI
+    tau = TAU
+
+INF = float('inf')
+NEG_INF = float('-inf')
+NAN = float('nan')
+
+class WierdNum(float, Enum):
+    inf = INF
+    neg_inf = NEG_INF
+    nan = NAN
+
+class TestEnum:
+
+    def test_floats(self):
+        for enum in FloatNum:
+            self.assertEqual(self.dumps(enum), repr(enum.value))
+            self.assertEqual(float(self.dumps(enum)), enum)
+            self.assertEqual(self.loads(self.dumps(enum)), enum)
+
+    def test_weird_floats(self):
+        for enum, expected in zip(WierdNum, ('Infinity', '-Infinity', 'NaN')):
+            self.assertEqual(self.dumps(enum), expected)
+            if not isnan(enum):
+                self.assertEqual(float(self.dumps(enum)), enum)
+                self.assertEqual(self.loads(self.dumps(enum)), enum)
+            else:
+                self.assertTrue(isnan(float(self.dumps(enum))))
+                self.assertTrue(isnan(self.loads(self.dumps(enum))))
+
+    def test_ints(self):
+        for enum in BigNum:
+            self.assertEqual(self.dumps(enum), str(enum.value))
+            self.assertEqual(int(self.dumps(enum)), enum)
+            self.assertEqual(self.loads(self.dumps(enum)), enum)
+
+    def test_list(self):
+        self.assertEqual(self.dumps(list(BigNum)),
+                         str([SMALL, BIG, HUGE, REALLY_HUGE]))
+        self.assertEqual(self.loads(self.dumps(list(BigNum))),
+                         list(BigNum))
+        self.assertEqual(self.dumps(list(FloatNum)),
+                         str([E, PI, TAU]))
+        self.assertEqual(self.loads(self.dumps(list(FloatNum))),
+                         list(FloatNum))
+        self.assertEqual(self.dumps(list(WierdNum)),
+                        '[Infinity, -Infinity, NaN]')
+        self.assertEqual(self.loads(self.dumps(list(WierdNum)))[:2],
+                         list(WierdNum)[:2])
+        self.assertTrue(isnan(self.loads(self.dumps(list(WierdNum)))[2]))
+
+    def test_dict_keys(self):
+        s, b, h, r = BigNum
+        e, p, t = FloatNum
+        i, j, n = WierdNum
+        d = {
+            s:'tiny', b:'large', h:'larger', r:'largest',
+            e:"Euler's number", p:'pi', t:'tau',
+            i:'Infinity', j:'-Infinity', n:'NaN',
+            }
+        nd = self.loads(self.dumps(d))
+        self.assertEqual(nd[str(SMALL)], 'tiny')
+        self.assertEqual(nd[str(BIG)], 'large')
+        self.assertEqual(nd[str(HUGE)], 'larger')
+        self.assertEqual(nd[str(REALLY_HUGE)], 'largest')
+        self.assertEqual(nd[repr(E)], "Euler's number")
+        self.assertEqual(nd[repr(PI)], 'pi')
+        self.assertEqual(nd[repr(TAU)], 'tau')
+        self.assertEqual(nd['Infinity'], 'Infinity')
+        self.assertEqual(nd['-Infinity'], '-Infinity')
+        self.assertEqual(nd['NaN'], 'NaN')
+
+    def test_dict_values(self):
+        d = dict(
+                tiny=BigNum.small,
+                large=BigNum.big,
+                larger=BigNum.huge,
+                largest=BigNum.really_huge,
+                e=FloatNum.e,
+                pi=FloatNum.pi,
+                tau=FloatNum.tau,
+                i=WierdNum.inf,
+                j=WierdNum.neg_inf,
+                n=WierdNum.nan,
+                )
+        nd = self.loads(self.dumps(d))
+        self.assertEqual(nd['tiny'], SMALL)
+        self.assertEqual(nd['large'], BIG)
+        self.assertEqual(nd['larger'], HUGE)
+        self.assertEqual(nd['largest'], REALLY_HUGE)
+        self.assertEqual(nd['e'], E)
+        self.assertEqual(nd['pi'], PI)
+        self.assertEqual(nd['tau'], TAU)
+        self.assertEqual(nd['i'], INF)
+        self.assertEqual(nd['j'], NEG_INF)
+        self.assertTrue(isnan(nd['n']))
+
+class TestPyEnum(TestEnum, PyTest): pass
+class TestCEnum(TestEnum, CTest): pass

--- a/tests/cpython/test_enum.py
+++ b/tests/cpython/test_enum.py
@@ -31,7 +31,7 @@ class WierdNum(float, Enum):
     neg_inf = NEG_INF
     nan = NAN
 
-class TestEnum:
+class _TestEnum:
 
     def test_floats(self):
         for enum in FloatNum:
@@ -116,5 +116,5 @@ class TestEnum:
         self.assertEqual(nd['j'], NEG_INF)
         self.assertTrue(isnan(nd['n']))
 
-class TestPyEnum(TestEnum, PyTest): pass
-class TestCEnum(TestEnum, CTest): pass
+class TestPyEnum(_TestEnum, PyTest): pass
+class TestCEnum(_TestEnum, CTest): pass

--- a/tests/cpython/test_enum.py
+++ b/tests/cpython/test_enum.py
@@ -1,6 +1,6 @@
 from enum import Enum, IntEnum
 from math import isnan
-from test.test_json import PyTest, CTest
+from cpython import PyTest, CTest, RustTest
 
 SMALL = 1
 BIG = 1<<32
@@ -118,3 +118,4 @@ class _TestEnum:
 
 class TestPyEnum(_TestEnum, PyTest): pass
 class TestCEnum(_TestEnum, CTest): pass
+class TestRustEnum(_TestEnum, RustTest): pass

--- a/tests/cpython/test_enum.py
+++ b/tests/cpython/test_enum.py
@@ -116,6 +116,6 @@ class _TestEnum:
         self.assertEqual(nd['j'], NEG_INF)
         self.assertTrue(isnan(nd['n']))
 
-class TestPyEnum(_TestEnum, PyTest): pass
-class TestCEnum(_TestEnum, CTest): pass
+# class TestPyEnum(_TestEnum, PyTest): pass
+# class TestCEnum(_TestEnum, CTest): pass
 class TestRustEnum(_TestEnum, RustTest): pass

--- a/tests/cpython/test_fail.py
+++ b/tests/cpython/test_fail.py
@@ -1,0 +1,216 @@
+from test.test_json import PyTest, CTest
+
+# 2007-10-05
+JSONDOCS = [
+    # http://json.org/JSON_checker/test/fail1.json
+    '"A JSON payload should be an object or array, not a string."',
+    # http://json.org/JSON_checker/test/fail2.json
+    '["Unclosed array"',
+    # http://json.org/JSON_checker/test/fail3.json
+    '{unquoted_key: "keys must be quoted"}',
+    # http://json.org/JSON_checker/test/fail4.json
+    '["extra comma",]',
+    # http://json.org/JSON_checker/test/fail5.json
+    '["double extra comma",,]',
+    # http://json.org/JSON_checker/test/fail6.json
+    '[   , "<-- missing value"]',
+    # http://json.org/JSON_checker/test/fail7.json
+    '["Comma after the close"],',
+    # http://json.org/JSON_checker/test/fail8.json
+    '["Extra close"]]',
+    # http://json.org/JSON_checker/test/fail9.json
+    '{"Extra comma": true,}',
+    # http://json.org/JSON_checker/test/fail10.json
+    '{"Extra value after close": true} "misplaced quoted value"',
+    # http://json.org/JSON_checker/test/fail11.json
+    '{"Illegal expression": 1 + 2}',
+    # http://json.org/JSON_checker/test/fail12.json
+    '{"Illegal invocation": alert()}',
+    # http://json.org/JSON_checker/test/fail13.json
+    '{"Numbers cannot have leading zeroes": 013}',
+    # http://json.org/JSON_checker/test/fail14.json
+    '{"Numbers cannot be hex": 0x14}',
+    # http://json.org/JSON_checker/test/fail15.json
+    '["Illegal backslash escape: \\x15"]',
+    # http://json.org/JSON_checker/test/fail16.json
+    '[\\naked]',
+    # http://json.org/JSON_checker/test/fail17.json
+    '["Illegal backslash escape: \\017"]',
+    # http://json.org/JSON_checker/test/fail18.json
+    '[[[[[[[[[[[[[[[[[[[["Too deep"]]]]]]]]]]]]]]]]]]]]',
+    # http://json.org/JSON_checker/test/fail19.json
+    '{"Missing colon" null}',
+    # http://json.org/JSON_checker/test/fail20.json
+    '{"Double colon":: null}',
+    # http://json.org/JSON_checker/test/fail21.json
+    '{"Comma instead of colon", null}',
+    # http://json.org/JSON_checker/test/fail22.json
+    '["Colon instead of comma": false]',
+    # http://json.org/JSON_checker/test/fail23.json
+    '["Bad value", truth]',
+    # http://json.org/JSON_checker/test/fail24.json
+    "['single quote']",
+    # http://json.org/JSON_checker/test/fail25.json
+    '["\ttab\tcharacter\tin\tstring\t"]',
+    # http://json.org/JSON_checker/test/fail26.json
+    '["tab\\   character\\   in\\  string\\  "]',
+    # http://json.org/JSON_checker/test/fail27.json
+    '["line\nbreak"]',
+    # http://json.org/JSON_checker/test/fail28.json
+    '["line\\\nbreak"]',
+    # http://json.org/JSON_checker/test/fail29.json
+    '[0e]',
+    # http://json.org/JSON_checker/test/fail30.json
+    '[0e+]',
+    # http://json.org/JSON_checker/test/fail31.json
+    '[0e+-1]',
+    # http://json.org/JSON_checker/test/fail32.json
+    '{"Comma instead if closing brace": true,',
+    # http://json.org/JSON_checker/test/fail33.json
+    '["mismatch"}',
+    # http://code.google.com/p/simplejson/issues/detail?id=3
+    '["A\u001FZ control characters in string"]',
+]
+
+SKIPS = {
+    1: "why not have a string payload?",
+    18: "spec doesn't specify any nesting limitations",
+}
+
+class TestFail:
+    def test_failures(self):
+        for idx, doc in enumerate(JSONDOCS):
+            idx = idx + 1
+            if idx in SKIPS:
+                self.loads(doc)
+                continue
+            try:
+                self.loads(doc)
+            except self.JSONDecodeError:
+                pass
+            else:
+                self.fail("Expected failure for fail{0}.json: {1!r}".format(idx, doc))
+
+    def test_non_string_keys_dict(self):
+        data = {'a' : 1, (1, 2) : 2}
+
+        #This is for c encoder
+        self.assertRaises(TypeError, self.dumps, data)
+
+        #This is for python encoder
+        self.assertRaises(TypeError, self.dumps, data, indent=True)
+
+    def test_truncated_input(self):
+        test_cases = [
+            ('', 'Expecting value', 0),
+            ('[', 'Expecting value', 1),
+            ('[42', "Expecting ',' delimiter", 3),
+            ('[42,', 'Expecting value', 4),
+            ('["', 'Unterminated string starting at', 1),
+            ('["spam', 'Unterminated string starting at', 1),
+            ('["spam"', "Expecting ',' delimiter", 7),
+            ('["spam",', 'Expecting value', 8),
+            ('{', 'Expecting property name enclosed in double quotes', 1),
+            ('{"', 'Unterminated string starting at', 1),
+            ('{"spam', 'Unterminated string starting at', 1),
+            ('{"spam"', "Expecting ':' delimiter", 7),
+            ('{"spam":', 'Expecting value', 8),
+            ('{"spam":42', "Expecting ',' delimiter", 10),
+            ('{"spam":42,', 'Expecting property name enclosed in double quotes', 11),
+        ]
+        test_cases += [
+            ('"', 'Unterminated string starting at', 0),
+            ('"spam', 'Unterminated string starting at', 0),
+        ]
+        for data, msg, idx in test_cases:
+            with self.assertRaises(self.JSONDecodeError) as cm:
+                self.loads(data)
+            err = cm.exception
+            self.assertEqual(err.msg, msg)
+            self.assertEqual(err.pos, idx)
+            self.assertEqual(err.lineno, 1)
+            self.assertEqual(err.colno, idx + 1)
+            self.assertEqual(str(err),
+                             '%s: line 1 column %d (char %d)' %
+                             (msg, idx + 1, idx))
+
+    def test_unexpected_data(self):
+        test_cases = [
+            ('[,', 'Expecting value', 1),
+            ('{"spam":[}', 'Expecting value', 9),
+            ('[42:', "Expecting ',' delimiter", 3),
+            ('[42 "spam"', "Expecting ',' delimiter", 4),
+            ('[42,]', 'Expecting value', 4),
+            ('{"spam":[42}', "Expecting ',' delimiter", 11),
+            ('["]', 'Unterminated string starting at', 1),
+            ('["spam":', "Expecting ',' delimiter", 7),
+            ('["spam",]', 'Expecting value', 8),
+            ('{:', 'Expecting property name enclosed in double quotes', 1),
+            ('{,', 'Expecting property name enclosed in double quotes', 1),
+            ('{42', 'Expecting property name enclosed in double quotes', 1),
+            ('[{]', 'Expecting property name enclosed in double quotes', 2),
+            ('{"spam",', "Expecting ':' delimiter", 7),
+            ('{"spam"}', "Expecting ':' delimiter", 7),
+            ('[{"spam"]', "Expecting ':' delimiter", 8),
+            ('{"spam":}', 'Expecting value', 8),
+            ('[{"spam":]', 'Expecting value', 9),
+            ('{"spam":42 "ham"', "Expecting ',' delimiter", 11),
+            ('[{"spam":42]', "Expecting ',' delimiter", 11),
+            ('{"spam":42,}', 'Expecting property name enclosed in double quotes', 11),
+        ]
+        for data, msg, idx in test_cases:
+            with self.assertRaises(self.JSONDecodeError) as cm:
+                self.loads(data)
+            err = cm.exception
+            self.assertEqual(err.msg, msg)
+            self.assertEqual(err.pos, idx)
+            self.assertEqual(err.lineno, 1)
+            self.assertEqual(err.colno, idx + 1)
+            self.assertEqual(str(err),
+                             '%s: line 1 column %d (char %d)' %
+                             (msg, idx + 1, idx))
+
+    def test_extra_data(self):
+        test_cases = [
+            ('[]]', 'Extra data', 2),
+            ('{}}', 'Extra data', 2),
+            ('[],[]', 'Extra data', 2),
+            ('{},{}', 'Extra data', 2),
+        ]
+        test_cases += [
+            ('42,"spam"', 'Extra data', 2),
+            ('"spam",42', 'Extra data', 6),
+        ]
+        for data, msg, idx in test_cases:
+            with self.assertRaises(self.JSONDecodeError) as cm:
+                self.loads(data)
+            err = cm.exception
+            self.assertEqual(err.msg, msg)
+            self.assertEqual(err.pos, idx)
+            self.assertEqual(err.lineno, 1)
+            self.assertEqual(err.colno, idx + 1)
+            self.assertEqual(str(err),
+                             '%s: line 1 column %d (char %d)' %
+                             (msg, idx + 1, idx))
+
+    def test_linecol(self):
+        test_cases = [
+            ('!', 1, 1, 0),
+            (' !', 1, 2, 1),
+            ('\n!', 2, 1, 1),
+            ('\n  \n\n     !', 4, 6, 10),
+        ]
+        for data, line, col, idx in test_cases:
+            with self.assertRaises(self.JSONDecodeError) as cm:
+                self.loads(data)
+            err = cm.exception
+            self.assertEqual(err.msg, 'Expecting value')
+            self.assertEqual(err.pos, idx)
+            self.assertEqual(err.lineno, line)
+            self.assertEqual(err.colno, col)
+            self.assertEqual(str(err),
+                             'Expecting value: line %s column %d (char %d)' %
+                             (line, col, idx))
+
+class TestPyFail(TestFail, PyTest): pass
+class TestCFail(TestFail, CTest): pass

--- a/tests/cpython/test_fail.py
+++ b/tests/cpython/test_fail.py
@@ -1,4 +1,4 @@
-from test.test_json import PyTest, CTest
+from cpython import PyTest, CTest, RustTest
 
 # 2007-10-05
 JSONDOCS = [
@@ -214,3 +214,4 @@ class _TestFail:
 
 class TestPyFail(_TestFail, PyTest): pass
 class TestCFail(_TestFail, CTest): pass
+class TestRustFail(_TestFail, RustTest): pass

--- a/tests/cpython/test_fail.py
+++ b/tests/cpython/test_fail.py
@@ -77,7 +77,7 @@ SKIPS = {
     18: "spec doesn't specify any nesting limitations",
 }
 
-class TestFail:
+class _TestFail:
     def test_failures(self):
         for idx, doc in enumerate(JSONDOCS):
             idx = idx + 1
@@ -212,5 +212,5 @@ class TestFail:
                              'Expecting value: line %s column %d (char %d)' %
                              (line, col, idx))
 
-class TestPyFail(TestFail, PyTest): pass
-class TestCFail(TestFail, CTest): pass
+class TestPyFail(_TestFail, PyTest): pass
+class TestCFail(_TestFail, CTest): pass

--- a/tests/cpython/test_fail.py
+++ b/tests/cpython/test_fail.py
@@ -212,6 +212,6 @@ class _TestFail:
                              'Expecting value: line %s column %d (char %d)' %
                              (line, col, idx))
 
-class TestPyFail(_TestFail, PyTest): pass
-class TestCFail(_TestFail, CTest): pass
+# class TestPyFail(_TestFail, PyTest): pass
+# class TestCFail(_TestFail, CTest): pass
 class TestRustFail(_TestFail, RustTest): pass

--- a/tests/cpython/test_float.py
+++ b/tests/cpython/test_float.py
@@ -1,0 +1,33 @@
+import math
+from test.test_json import PyTest, CTest
+
+
+class TestFloat:
+    def test_floats(self):
+        for num in [1617161771.7650001, math.pi, math.pi**100, math.pi**-100, 3.1]:
+            self.assertEqual(float(self.dumps(num)), num)
+            self.assertEqual(self.loads(self.dumps(num)), num)
+
+    def test_ints(self):
+        for num in [1, 1<<32, 1<<64]:
+            self.assertEqual(self.dumps(num), str(num))
+            self.assertEqual(int(self.dumps(num)), num)
+
+    def test_out_of_range(self):
+        self.assertEqual(self.loads('[23456789012E666]'), [float('inf')])
+        self.assertEqual(self.loads('[-23456789012E666]'), [float('-inf')])
+
+    def test_allow_nan(self):
+        for val in (float('inf'), float('-inf'), float('nan')):
+            out = self.dumps([val])
+            if val == val:  # inf
+                self.assertEqual(self.loads(out), [val])
+            else:  # nan
+                res = self.loads(out)
+                self.assertEqual(len(res), 1)
+                self.assertNotEqual(res[0], res[0])
+            self.assertRaises(ValueError, self.dumps, [val], allow_nan=False)
+
+
+class TestPyFloat(TestFloat, PyTest): pass
+class TestCFloat(TestFloat, CTest): pass

--- a/tests/cpython/test_float.py
+++ b/tests/cpython/test_float.py
@@ -2,7 +2,7 @@ import math
 from test.test_json import PyTest, CTest
 
 
-class TestFloat:
+class _TestFloat:
     def test_floats(self):
         for num in [1617161771.7650001, math.pi, math.pi**100, math.pi**-100, 3.1]:
             self.assertEqual(float(self.dumps(num)), num)
@@ -29,5 +29,5 @@ class TestFloat:
             self.assertRaises(ValueError, self.dumps, [val], allow_nan=False)
 
 
-class TestPyFloat(TestFloat, PyTest): pass
-class TestCFloat(TestFloat, CTest): pass
+class TestPyFloat(_TestFloat, PyTest): pass
+class TestCFloat(_TestFloat, CTest): pass

--- a/tests/cpython/test_float.py
+++ b/tests/cpython/test_float.py
@@ -1,5 +1,5 @@
 import math
-from test.test_json import PyTest, CTest
+from cpython import PyTest, CTest, RustTest
 
 
 class _TestFloat:
@@ -31,3 +31,4 @@ class _TestFloat:
 
 class TestPyFloat(_TestFloat, PyTest): pass
 class TestCFloat(_TestFloat, CTest): pass
+class TestRustFloat(_TestFloat, RustTest): pass

--- a/tests/cpython/test_float.py
+++ b/tests/cpython/test_float.py
@@ -29,6 +29,6 @@ class _TestFloat:
             self.assertRaises(ValueError, self.dumps, [val], allow_nan=False)
 
 
-class TestPyFloat(_TestFloat, PyTest): pass
-class TestCFloat(_TestFloat, CTest): pass
+# class TestPyFloat(_TestFloat, PyTest): pass
+# class TestCFloat(_TestFloat, CTest): pass
 class TestRustFloat(_TestFloat, RustTest): pass

--- a/tests/cpython/test_indent.py
+++ b/tests/cpython/test_indent.py
@@ -1,0 +1,67 @@
+import textwrap
+from io import StringIO
+from test.test_json import PyTest, CTest
+
+
+class TestIndent:
+    def test_indent(self):
+        h = [['blorpie'], ['whoops'], [], 'd-shtaeou', 'd-nthiouh', 'i-vhbjkhnth',
+             {'nifty': 87}, {'field': 'yes', 'morefield': False} ]
+
+        expect = textwrap.dedent("""\
+        [
+        \t[
+        \t\t"blorpie"
+        \t],
+        \t[
+        \t\t"whoops"
+        \t],
+        \t[],
+        \t"d-shtaeou",
+        \t"d-nthiouh",
+        \t"i-vhbjkhnth",
+        \t{
+        \t\t"nifty": 87
+        \t},
+        \t{
+        \t\t"field": "yes",
+        \t\t"morefield": false
+        \t}
+        ]""")
+
+        d1 = self.dumps(h)
+        d2 = self.dumps(h, indent=2, sort_keys=True, separators=(',', ': '))
+        d3 = self.dumps(h, indent='\t', sort_keys=True, separators=(',', ': '))
+        d4 = self.dumps(h, indent=2, sort_keys=True)
+        d5 = self.dumps(h, indent='\t', sort_keys=True)
+
+        h1 = self.loads(d1)
+        h2 = self.loads(d2)
+        h3 = self.loads(d3)
+
+        self.assertEqual(h1, h)
+        self.assertEqual(h2, h)
+        self.assertEqual(h3, h)
+        self.assertEqual(d2, expect.expandtabs(2))
+        self.assertEqual(d3, expect)
+        self.assertEqual(d4, d2)
+        self.assertEqual(d5, d3)
+
+    def test_indent0(self):
+        h = {3: 1}
+        def check(indent, expected):
+            d1 = self.dumps(h, indent=indent)
+            self.assertEqual(d1, expected)
+
+            sio = StringIO()
+            self.json.dump(h, sio, indent=indent)
+            self.assertEqual(sio.getvalue(), expected)
+
+        # indent=0 should emit newlines
+        check(0, '{\n"3": 1\n}')
+        # indent=None is more compact
+        check(None, '{"3": 1}')
+
+
+class TestPyIndent(TestIndent, PyTest): pass
+class TestCIndent(TestIndent, CTest): pass

--- a/tests/cpython/test_indent.py
+++ b/tests/cpython/test_indent.py
@@ -3,7 +3,7 @@ from io import StringIO
 from test.test_json import PyTest, CTest
 
 
-class TestIndent:
+class _TestIndent:
     def test_indent(self):
         h = [['blorpie'], ['whoops'], [], 'd-shtaeou', 'd-nthiouh', 'i-vhbjkhnth',
              {'nifty': 87}, {'field': 'yes', 'morefield': False} ]
@@ -63,5 +63,5 @@ class TestIndent:
         check(None, '{"3": 1}')
 
 
-class TestPyIndent(TestIndent, PyTest): pass
-class TestCIndent(TestIndent, CTest): pass
+class TestPyIndent(_TestIndent, PyTest): pass
+class TestCIndent(_TestIndent, CTest): pass

--- a/tests/cpython/test_indent.py
+++ b/tests/cpython/test_indent.py
@@ -63,6 +63,6 @@ class _TestIndent:
         check(None, '{"3": 1}')
 
 
-class TestPyIndent(_TestIndent, PyTest): pass
-class TestCIndent(_TestIndent, CTest): pass
+# class TestPyIndent(_TestIndent, PyTest): pass
+# class TestCIndent(_TestIndent, CTest): pass
 class TestRustIndent(_TestIndent, RustTest): pass

--- a/tests/cpython/test_indent.py
+++ b/tests/cpython/test_indent.py
@@ -1,6 +1,6 @@
 import textwrap
 from io import StringIO
-from test.test_json import PyTest, CTest
+from cpython import PyTest, CTest, RustTest
 
 
 class _TestIndent:
@@ -65,3 +65,4 @@ class _TestIndent:
 
 class TestPyIndent(_TestIndent, PyTest): pass
 class TestCIndent(_TestIndent, CTest): pass
+class TestRustIndent(_TestIndent, RustTest): pass

--- a/tests/cpython/test_pass1.py
+++ b/tests/cpython/test_pass1.py
@@ -1,0 +1,75 @@
+from test.test_json import PyTest, CTest
+
+
+# from http://json.org/JSON_checker/test/pass1.json
+JSON = r'''
+[
+    "JSON Test Pattern pass1",
+    {"object with 1 member":["array with 1 element"]},
+    {},
+    [],
+    -42,
+    true,
+    false,
+    null,
+    {
+        "integer": 1234567890,
+        "real": -9876.543210,
+        "e": 0.123456789e-12,
+        "E": 1.234567890E+34,
+        "":  23456789012E66,
+        "zero": 0,
+        "one": 1,
+        "space": " ",
+        "quote": "\"",
+        "backslash": "\\",
+        "controls": "\b\f\n\r\t",
+        "slash": "/ & \/",
+        "alpha": "abcdefghijklmnopqrstuvwyz",
+        "ALPHA": "ABCDEFGHIJKLMNOPQRSTUVWYZ",
+        "digit": "0123456789",
+        "0123456789": "digit",
+        "special": "`1~!@#$%^&*()_+-={':[,]}|;.</>?",
+        "hex": "\u0123\u4567\u89AB\uCDEF\uabcd\uef4A",
+        "true": true,
+        "false": false,
+        "null": null,
+        "array":[  ],
+        "object":{  },
+        "address": "50 St. James Street",
+        "url": "http://www.JSON.org/",
+        "comment": "// /* <!-- --",
+        "# -- --> */": " ",
+        " s p a c e d " :[1,2 , 3
+
+,
+
+4 , 5        ,          6           ,7        ],"compact":[1,2,3,4,5,6,7],
+        "jsontext": "{\"object with 1 member\":[\"array with 1 element\"]}",
+        "quotes": "&#34; \u0022 %22 0x22 034 &#x22;",
+        "\/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?"
+: "A key can be any string"
+    },
+    0.5 ,98.6
+,
+99.44
+,
+
+1066,
+1e1,
+0.1e1,
+1e-1,
+1e00,2e+00,2e-00
+,"rosebud"]
+'''
+
+class TestPass1:
+    def test_parse(self):
+        # test in/out equivalence and parsing
+        res = self.loads(JSON)
+        out = self.dumps(res)
+        self.assertEqual(res, self.loads(out))
+
+
+class TestPyPass1(TestPass1, PyTest): pass
+class TestCPass1(TestPass1, CTest): pass

--- a/tests/cpython/test_pass1.py
+++ b/tests/cpython/test_pass1.py
@@ -1,4 +1,4 @@
-from test.test_json import PyTest, CTest
+from cpython import PyTest, CTest, RustTest
 
 
 # from http://json.org/JSON_checker/test/pass1.json
@@ -73,3 +73,4 @@ class _TestPass1:
 
 class TestPyPass1(_TestPass1, PyTest): pass
 class TestCPass1(_TestPass1, CTest): pass
+class TestRustPass1(_TestPass1, RustTest): pass

--- a/tests/cpython/test_pass1.py
+++ b/tests/cpython/test_pass1.py
@@ -71,6 +71,6 @@ class _TestPass1:
         self.assertEqual(res, self.loads(out))
 
 
-class TestPyPass1(_TestPass1, PyTest): pass
-class TestCPass1(_TestPass1, CTest): pass
+# class TestPyPass1(_TestPass1, PyTest): pass
+# class TestCPass1(_TestPass1, CTest): pass
 class TestRustPass1(_TestPass1, RustTest): pass

--- a/tests/cpython/test_pass1.py
+++ b/tests/cpython/test_pass1.py
@@ -63,7 +63,7 @@ JSON = r'''
 ,"rosebud"]
 '''
 
-class TestPass1:
+class _TestPass1:
     def test_parse(self):
         # test in/out equivalence and parsing
         res = self.loads(JSON)
@@ -71,5 +71,5 @@ class TestPass1:
         self.assertEqual(res, self.loads(out))
 
 
-class TestPyPass1(TestPass1, PyTest): pass
-class TestCPass1(TestPass1, CTest): pass
+class TestPyPass1(_TestPass1, PyTest): pass
+class TestCPass1(_TestPass1, CTest): pass

--- a/tests/cpython/test_pass2.py
+++ b/tests/cpython/test_pass2.py
@@ -1,0 +1,18 @@
+from test.test_json import PyTest, CTest
+
+
+# from http://json.org/JSON_checker/test/pass2.json
+JSON = r'''
+[[[[[[[[[[[[[[[[[[["Not too deep"]]]]]]]]]]]]]]]]]]]
+'''
+
+class TestPass2:
+    def test_parse(self):
+        # test in/out equivalence and parsing
+        res = self.loads(JSON)
+        out = self.dumps(res)
+        self.assertEqual(res, self.loads(out))
+
+
+class TestPyPass2(TestPass2, PyTest): pass
+class TestCPass2(TestPass2, CTest): pass

--- a/tests/cpython/test_pass2.py
+++ b/tests/cpython/test_pass2.py
@@ -6,7 +6,7 @@ JSON = r'''
 [[[[[[[[[[[[[[[[[[["Not too deep"]]]]]]]]]]]]]]]]]]]
 '''
 
-class TestPass2:
+class _TestPass2:
     def test_parse(self):
         # test in/out equivalence and parsing
         res = self.loads(JSON)
@@ -14,5 +14,5 @@ class TestPass2:
         self.assertEqual(res, self.loads(out))
 
 
-class TestPyPass2(TestPass2, PyTest): pass
-class TestCPass2(TestPass2, CTest): pass
+class TestPyPass2(_TestPass2, PyTest): pass
+class TestCPass2(_TestPass2, CTest): pass

--- a/tests/cpython/test_pass2.py
+++ b/tests/cpython/test_pass2.py
@@ -14,6 +14,6 @@ class _TestPass2:
         self.assertEqual(res, self.loads(out))
 
 
-class TestPyPass2(_TestPass2, PyTest): pass
-class TestCPass2(_TestPass2, CTest): pass
+# class TestPyPass2(_TestPass2, PyTest): pass
+# class TestCPass2(_TestPass2, CTest): pass
 class TestRustPass2(_TestPass2, RustTest): pass

--- a/tests/cpython/test_pass2.py
+++ b/tests/cpython/test_pass2.py
@@ -1,4 +1,4 @@
-from test.test_json import PyTest, CTest
+from cpython import PyTest, CTest, RustTest
 
 
 # from http://json.org/JSON_checker/test/pass2.json
@@ -16,3 +16,4 @@ class _TestPass2:
 
 class TestPyPass2(_TestPass2, PyTest): pass
 class TestCPass2(_TestPass2, CTest): pass
+class TestRustPass2(_TestPass2, RustTest): pass

--- a/tests/cpython/test_pass3.py
+++ b/tests/cpython/test_pass3.py
@@ -1,0 +1,24 @@
+from test.test_json import PyTest, CTest
+
+
+# from http://json.org/JSON_checker/test/pass3.json
+JSON = r'''
+{
+    "JSON Test Pattern pass3": {
+        "The outermost value": "must be an object or array.",
+        "In this test": "It is an object."
+    }
+}
+'''
+
+
+class TestPass3:
+    def test_parse(self):
+        # test in/out equivalence and parsing
+        res = self.loads(JSON)
+        out = self.dumps(res)
+        self.assertEqual(res, self.loads(out))
+
+
+class TestPyPass3(TestPass3, PyTest): pass
+class TestCPass3(TestPass3, CTest): pass

--- a/tests/cpython/test_pass3.py
+++ b/tests/cpython/test_pass3.py
@@ -12,7 +12,7 @@ JSON = r'''
 '''
 
 
-class TestPass3:
+class _TestPass3:
     def test_parse(self):
         # test in/out equivalence and parsing
         res = self.loads(JSON)
@@ -20,5 +20,5 @@ class TestPass3:
         self.assertEqual(res, self.loads(out))
 
 
-class TestPyPass3(TestPass3, PyTest): pass
-class TestCPass3(TestPass3, CTest): pass
+class TestPyPass3(_TestPass3, PyTest): pass
+class TestCPass3(_TestPass3, CTest): pass

--- a/tests/cpython/test_pass3.py
+++ b/tests/cpython/test_pass3.py
@@ -1,4 +1,4 @@
-from test.test_json import PyTest, CTest
+from cpython import PyTest, CTest, RustTest
 
 
 # from http://json.org/JSON_checker/test/pass3.json
@@ -22,3 +22,4 @@ class _TestPass3:
 
 class TestPyPass3(_TestPass3, PyTest): pass
 class TestCPass3(_TestPass3, CTest): pass
+class TestRustPass3(_TestPass3, RustTest): pass

--- a/tests/cpython/test_pass3.py
+++ b/tests/cpython/test_pass3.py
@@ -20,6 +20,6 @@ class _TestPass3:
         self.assertEqual(res, self.loads(out))
 
 
-class TestPyPass3(_TestPass3, PyTest): pass
-class TestCPass3(_TestPass3, CTest): pass
+# class TestPyPass3(_TestPass3, PyTest): pass
+# class TestCPass3(_TestPass3, CTest): pass
 class TestRustPass3(_TestPass3, RustTest): pass

--- a/tests/cpython/test_recursion.py
+++ b/tests/cpython/test_recursion.py
@@ -1,0 +1,100 @@
+from test.test_json import PyTest, CTest
+
+
+class JSONTestObject:
+    pass
+
+
+class TestRecursion:
+    def test_listrecursion(self):
+        x = []
+        x.append(x)
+        try:
+            self.dumps(x)
+        except ValueError:
+            pass
+        else:
+            self.fail("didn't raise ValueError on list recursion")
+        x = []
+        y = [x]
+        x.append(y)
+        try:
+            self.dumps(x)
+        except ValueError:
+            pass
+        else:
+            self.fail("didn't raise ValueError on alternating list recursion")
+        y = []
+        x = [y, y]
+        # ensure that the marker is cleared
+        self.dumps(x)
+
+    def test_dictrecursion(self):
+        x = {}
+        x["test"] = x
+        try:
+            self.dumps(x)
+        except ValueError:
+            pass
+        else:
+            self.fail("didn't raise ValueError on dict recursion")
+        x = {}
+        y = {"a": x, "b": x}
+        # ensure that the marker is cleared
+        self.dumps(x)
+
+    def test_defaultrecursion(self):
+        class RecursiveJSONEncoder(self.json.JSONEncoder):
+            recurse = False
+            def default(self, o):
+                if o is JSONTestObject:
+                    if self.recurse:
+                        return [JSONTestObject]
+                    else:
+                        return 'JSONTestObject'
+                return pyjson.JSONEncoder.default(o)
+
+        enc = RecursiveJSONEncoder()
+        self.assertEqual(enc.encode(JSONTestObject), '"JSONTestObject"')
+        enc.recurse = True
+        try:
+            enc.encode(JSONTestObject)
+        except ValueError:
+            pass
+        else:
+            self.fail("didn't raise ValueError on default recursion")
+
+
+    def test_highly_nested_objects_decoding(self):
+        # test that loading highly-nested objects doesn't segfault when C
+        # accelerations are used. See #12017
+        with self.assertRaises(RecursionError):
+            self.loads('{"a":' * 100000 + '1' + '}' * 100000)
+        with self.assertRaises(RecursionError):
+            self.loads('{"a":' * 100000 + '[1]' + '}' * 100000)
+        with self.assertRaises(RecursionError):
+            self.loads('[' * 100000 + '1' + ']' * 100000)
+
+    def test_highly_nested_objects_encoding(self):
+        # See #12051
+        l, d = [], {}
+        for x in range(100000):
+            l, d = [l], {'k':d}
+        with self.assertRaises(RecursionError):
+            self.dumps(l)
+        with self.assertRaises(RecursionError):
+            self.dumps(d)
+
+    def test_endless_recursion(self):
+        # See #12051
+        class EndlessJSONEncoder(self.json.JSONEncoder):
+            def default(self, o):
+                """If check_circular is False, this will keep adding another list."""
+                return [o]
+
+        with self.assertRaises(RecursionError):
+            EndlessJSONEncoder(check_circular=False).encode(5j)
+
+
+class TestPyRecursion(TestRecursion, PyTest): pass
+class TestCRecursion(TestRecursion, CTest): pass

--- a/tests/cpython/test_recursion.py
+++ b/tests/cpython/test_recursion.py
@@ -96,6 +96,6 @@ class _TestRecursion:
             EndlessJSONEncoder(check_circular=False).encode(5j)
 
 
-class TestPyRecursion(_TestRecursion, PyTest): pass
-class TestCRecursion(_TestRecursion, CTest): pass
+# class TestPyRecursion(_TestRecursion, PyTest): pass
+# class TestCRecursion(_TestRecursion, CTest): pass
 class TestRustRecursion(_TestRecursion, RustTest): pass

--- a/tests/cpython/test_recursion.py
+++ b/tests/cpython/test_recursion.py
@@ -5,7 +5,7 @@ class JSONTestObject:
     pass
 
 
-class TestRecursion:
+class _TestRecursion:
     def test_listrecursion(self):
         x = []
         x.append(x)
@@ -96,5 +96,5 @@ class TestRecursion:
             EndlessJSONEncoder(check_circular=False).encode(5j)
 
 
-class TestPyRecursion(TestRecursion, PyTest): pass
-class TestCRecursion(TestRecursion, CTest): pass
+class TestPyRecursion(_TestRecursion, PyTest): pass
+class TestCRecursion(_TestRecursion, CTest): pass

--- a/tests/cpython/test_recursion.py
+++ b/tests/cpython/test_recursion.py
@@ -98,4 +98,6 @@ class _TestRecursion:
 
 # class TestPyRecursion(_TestRecursion, PyTest): pass
 # class TestCRecursion(_TestRecursion, CTest): pass
-class TestRustRecursion(_TestRecursion, RustTest): pass
+
+# FIXME: this will crash hyperjson
+# class TestRustRecursion(_TestRecursion, RustTest): pass

--- a/tests/cpython/test_recursion.py
+++ b/tests/cpython/test_recursion.py
@@ -1,4 +1,4 @@
-from test.test_json import PyTest, CTest
+from cpython import PyTest, CTest, RustTest
 
 
 class JSONTestObject:
@@ -98,3 +98,4 @@ class _TestRecursion:
 
 class TestPyRecursion(_TestRecursion, PyTest): pass
 class TestCRecursion(_TestRecursion, CTest): pass
+class TestRustRecursion(_TestRecursion, RustTest): pass

--- a/tests/cpython/test_scanstring.py
+++ b/tests/cpython/test_scanstring.py
@@ -1,0 +1,141 @@
+import sys
+from test.test_json import PyTest, CTest
+
+
+class TestScanstring:
+    def test_scanstring(self):
+        scanstring = self.json.decoder.scanstring
+        self.assertEqual(
+            scanstring('"z\U0001d120x"', 1, True),
+            ('z\U0001d120x', 5))
+
+        self.assertEqual(
+            scanstring('"\\u007b"', 1, True),
+            ('{', 8))
+
+        self.assertEqual(
+            scanstring('"A JSON payload should be an object or array, not a string."', 1, True),
+            ('A JSON payload should be an object or array, not a string.', 60))
+
+        self.assertEqual(
+            scanstring('["Unclosed array"', 2, True),
+            ('Unclosed array', 17))
+
+        self.assertEqual(
+            scanstring('["extra comma",]', 2, True),
+            ('extra comma', 14))
+
+        self.assertEqual(
+            scanstring('["double extra comma",,]', 2, True),
+            ('double extra comma', 21))
+
+        self.assertEqual(
+            scanstring('["Comma after the close"],', 2, True),
+            ('Comma after the close', 24))
+
+        self.assertEqual(
+            scanstring('["Extra close"]]', 2, True),
+            ('Extra close', 14))
+
+        self.assertEqual(
+            scanstring('{"Extra comma": true,}', 2, True),
+            ('Extra comma', 14))
+
+        self.assertEqual(
+            scanstring('{"Extra value after close": true} "misplaced quoted value"', 2, True),
+            ('Extra value after close', 26))
+
+        self.assertEqual(
+            scanstring('{"Illegal expression": 1 + 2}', 2, True),
+            ('Illegal expression', 21))
+
+        self.assertEqual(
+            scanstring('{"Illegal invocation": alert()}', 2, True),
+            ('Illegal invocation', 21))
+
+        self.assertEqual(
+            scanstring('{"Numbers cannot have leading zeroes": 013}', 2, True),
+            ('Numbers cannot have leading zeroes', 37))
+
+        self.assertEqual(
+            scanstring('{"Numbers cannot be hex": 0x14}', 2, True),
+            ('Numbers cannot be hex', 24))
+
+        self.assertEqual(
+            scanstring('[[[[[[[[[[[[[[[[[[[["Too deep"]]]]]]]]]]]]]]]]]]]]', 21, True),
+            ('Too deep', 30))
+
+        self.assertEqual(
+            scanstring('{"Missing colon" null}', 2, True),
+            ('Missing colon', 16))
+
+        self.assertEqual(
+            scanstring('{"Double colon":: null}', 2, True),
+            ('Double colon', 15))
+
+        self.assertEqual(
+            scanstring('{"Comma instead of colon", null}', 2, True),
+            ('Comma instead of colon', 25))
+
+        self.assertEqual(
+            scanstring('["Colon instead of comma": false]', 2, True),
+            ('Colon instead of comma', 25))
+
+        self.assertEqual(
+            scanstring('["Bad value", truth]', 2, True),
+            ('Bad value', 12))
+
+    def test_surrogates(self):
+        scanstring = self.json.decoder.scanstring
+        def assertScan(given, expect):
+            self.assertEqual(scanstring(given, 1, True),
+                             (expect, len(given)))
+
+        assertScan('"z\\ud834\\u0079x"', 'z\ud834yx')
+        assertScan('"z\\ud834\\udd20x"', 'z\U0001d120x')
+        assertScan('"z\\ud834\\ud834\\udd20x"', 'z\ud834\U0001d120x')
+        assertScan('"z\\ud834x"', 'z\ud834x')
+        assertScan('"z\\ud834\udd20x12345"', 'z\ud834\udd20x12345')
+        assertScan('"z\\udd20x"', 'z\udd20x')
+        assertScan('"z\ud834\udd20x"', 'z\ud834\udd20x')
+        assertScan('"z\ud834\\udd20x"', 'z\ud834\udd20x')
+        assertScan('"z\ud834x"', 'z\ud834x')
+
+    def test_bad_escapes(self):
+        scanstring = self.json.decoder.scanstring
+        bad_escapes = [
+            '"\\"',
+            '"\\x"',
+            '"\\u"',
+            '"\\u0"',
+            '"\\u01"',
+            '"\\u012"',
+            '"\\uz012"',
+            '"\\u0z12"',
+            '"\\u01z2"',
+            '"\\u012z"',
+            '"\\u0x12"',
+            '"\\u0X12"',
+            '"\\ud834\\"',
+            '"\\ud834\\u"',
+            '"\\ud834\\ud"',
+            '"\\ud834\\udd"',
+            '"\\ud834\\udd2"',
+            '"\\ud834\\uzdd2"',
+            '"\\ud834\\udzd2"',
+            '"\\ud834\\uddz2"',
+            '"\\ud834\\udd2z"',
+            '"\\ud834\\u0x20"',
+            '"\\ud834\\u0X20"',
+        ]
+        for s in bad_escapes:
+            with self.assertRaises(self.JSONDecodeError, msg=s):
+                scanstring(s, 1, True)
+
+    def test_overflow(self):
+        with self.assertRaises(OverflowError):
+            self.json.decoder.scanstring(b"xxx", sys.maxsize+1)
+
+
+class TestPyScanstring(TestScanstring, PyTest): pass
+class TestCScanstring(TestScanstring, CTest): pass

--- a/tests/cpython/test_scanstring.py
+++ b/tests/cpython/test_scanstring.py
@@ -1,5 +1,5 @@
 import sys
-from test.test_json import PyTest, CTest
+from cpython import PyTest, CTest, RustTest
 
 
 class _TestScanstring:
@@ -139,3 +139,4 @@ class _TestScanstring:
 
 class TestPyScanstring(_TestScanstring, PyTest): pass
 class TestCScanstring(_TestScanstring, CTest): pass
+class TestRustScanstring(_TestScanstring, RustTest): pass

--- a/tests/cpython/test_scanstring.py
+++ b/tests/cpython/test_scanstring.py
@@ -137,6 +137,6 @@ class _TestScanstring:
             self.json.decoder.scanstring(b"xxx", sys.maxsize+1)
 
 
-class TestPyScanstring(_TestScanstring, PyTest): pass
-class TestCScanstring(_TestScanstring, CTest): pass
+# class TestPyScanstring(_TestScanstring, PyTest): pass
+# class TestCScanstring(_TestScanstring, CTest): pass
 class TestRustScanstring(_TestScanstring, RustTest): pass

--- a/tests/cpython/test_scanstring.py
+++ b/tests/cpython/test_scanstring.py
@@ -2,7 +2,7 @@ import sys
 from test.test_json import PyTest, CTest
 
 
-class TestScanstring:
+class _TestScanstring:
     def test_scanstring(self):
         scanstring = self.json.decoder.scanstring
         self.assertEqual(
@@ -137,5 +137,5 @@ class TestScanstring:
             self.json.decoder.scanstring(b"xxx", sys.maxsize+1)
 
 
-class TestPyScanstring(TestScanstring, PyTest): pass
-class TestCScanstring(TestScanstring, CTest): pass
+class TestPyScanstring(_TestScanstring, PyTest): pass
+class TestCScanstring(_TestScanstring, CTest): pass

--- a/tests/cpython/test_separators.py
+++ b/tests/cpython/test_separators.py
@@ -1,0 +1,50 @@
+import textwrap
+from test.test_json import PyTest, CTest
+
+
+class TestSeparators:
+    def test_separators(self):
+        h = [['blorpie'], ['whoops'], [], 'd-shtaeou', 'd-nthiouh', 'i-vhbjkhnth',
+             {'nifty': 87}, {'field': 'yes', 'morefield': False} ]
+
+        expect = textwrap.dedent("""\
+        [
+          [
+            "blorpie"
+          ] ,
+          [
+            "whoops"
+          ] ,
+          [] ,
+          "d-shtaeou" ,
+          "d-nthiouh" ,
+          "i-vhbjkhnth" ,
+          {
+            "nifty" : 87
+          } ,
+          {
+            "field" : "yes" ,
+            "morefield" : false
+          }
+        ]""")
+
+
+        d1 = self.dumps(h)
+        d2 = self.dumps(h, indent=2, sort_keys=True, separators=(' ,', ' : '))
+
+        h1 = self.loads(d1)
+        h2 = self.loads(d2)
+
+        self.assertEqual(h1, h)
+        self.assertEqual(h2, h)
+        self.assertEqual(d2, expect)
+
+    def test_illegal_separators(self):
+        h = {1: 2, 3: 4}
+        self.assertRaises(TypeError, self.dumps, h, separators=(b', ', ': '))
+        self.assertRaises(TypeError, self.dumps, h, separators=(', ', b': '))
+        self.assertRaises(TypeError, self.dumps, h, separators=(b', ', b': '))
+
+
+class TestPySeparators(TestSeparators, PyTest): pass
+class TestCSeparators(TestSeparators, CTest): pass

--- a/tests/cpython/test_separators.py
+++ b/tests/cpython/test_separators.py
@@ -2,7 +2,7 @@ import textwrap
 from test.test_json import PyTest, CTest
 
 
-class TestSeparators:
+class _TestSeparators:
     def test_separators(self):
         h = [['blorpie'], ['whoops'], [], 'd-shtaeou', 'd-nthiouh', 'i-vhbjkhnth',
              {'nifty': 87}, {'field': 'yes', 'morefield': False} ]
@@ -46,5 +46,5 @@ class TestSeparators:
         self.assertRaises(TypeError, self.dumps, h, separators=(b', ', b': '))
 
 
-class TestPySeparators(TestSeparators, PyTest): pass
-class TestCSeparators(TestSeparators, CTest): pass
+class TestPySeparators(_TestSeparators, PyTest): pass
+class TestCSeparators(_TestSeparators, CTest): pass

--- a/tests/cpython/test_separators.py
+++ b/tests/cpython/test_separators.py
@@ -1,5 +1,5 @@
 import textwrap
-from test.test_json import PyTest, CTest
+from cpython import PyTest, CTest, RustTest
 
 
 class _TestSeparators:
@@ -48,3 +48,4 @@ class _TestSeparators:
 
 class TestPySeparators(_TestSeparators, PyTest): pass
 class TestCSeparators(_TestSeparators, CTest): pass
+class TestRustSeparators(_TestSeparators, RustTest): pass

--- a/tests/cpython/test_separators.py
+++ b/tests/cpython/test_separators.py
@@ -46,6 +46,6 @@ class _TestSeparators:
         self.assertRaises(TypeError, self.dumps, h, separators=(b', ', b': '))
 
 
-class TestPySeparators(_TestSeparators, PyTest): pass
-class TestCSeparators(_TestSeparators, CTest): pass
+# class TestPySeparators(_TestSeparators, PyTest): pass
+# class TestCSeparators(_TestSeparators, CTest): pass
 class TestRustSeparators(_TestSeparators, RustTest): pass

--- a/tests/cpython/test_speedups.py
+++ b/tests/cpython/test_speedups.py
@@ -1,0 +1,71 @@
+from test.test_json import CTest
+
+
+class BadBool:
+    def __bool__(self):
+        1/0
+
+
+class TestSpeedups(CTest):
+    def test_scanstring(self):
+        self.assertEqual(self.json.decoder.scanstring.__module__, "_json")
+        self.assertIs(self.json.decoder.scanstring, self.json.decoder.c_scanstring)
+
+    def test_encode_basestring_ascii(self):
+        self.assertEqual(self.json.encoder.encode_basestring_ascii.__module__,
+                         "_json")
+        self.assertIs(self.json.encoder.encode_basestring_ascii,
+                      self.json.encoder.c_encode_basestring_ascii)
+
+
+class TestDecode(CTest):
+    def test_make_scanner(self):
+        self.assertRaises(AttributeError, self.json.scanner.c_make_scanner, 1)
+
+    def test_bad_bool_args(self):
+        def test(value):
+            self.json.decoder.JSONDecoder(strict=BadBool()).decode(value)
+        self.assertRaises(ZeroDivisionError, test, '""')
+        self.assertRaises(ZeroDivisionError, test, '{}')
+
+
+class TestEncode(CTest):
+    def test_make_encoder(self):
+        self.assertRaises(TypeError, self.json.encoder.c_make_encoder,
+            (True, False),
+            b"\xCD\x7D\x3D\x4E\x12\x4C\xF9\x79\xD7\x52\xBA\x82\xF2\x27\x4A\x7D\xA0\xCA\x75",
+            None)
+
+    def test_bad_str_encoder(self):
+        # Issue #31505: There shouldn't be an assertion failure in case
+        # c_make_encoder() receives a bad encoder() argument.
+        def bad_encoder1(*args):
+            return None
+        enc = self.json.encoder.c_make_encoder(None, lambda obj: str(obj),
+                                               bad_encoder1, None, ': ', ', ',
+                                               False, False, False)
+        with self.assertRaises(TypeError):
+            enc('spam', 4)
+        with self.assertRaises(TypeError):
+            enc({'spam': 42}, 4)
+
+        def bad_encoder2(*args):
+            1/0
+        enc = self.json.encoder.c_make_encoder(None, lambda obj: str(obj),
+                                               bad_encoder2, None, ': ', ', ',
+                                               False, False, False)
+        with self.assertRaises(ZeroDivisionError):
+            enc('spam', 4)
+
+    def test_bad_bool_args(self):
+        def test(name):
+            self.json.encoder.JSONEncoder(**{name: BadBool()}).encode({'a': 1})
+        self.assertRaises(ZeroDivisionError, test, 'skipkeys')
+        self.assertRaises(ZeroDivisionError, test, 'ensure_ascii')
+        self.assertRaises(ZeroDivisionError, test, 'check_circular')
+        self.assertRaises(ZeroDivisionError, test, 'allow_nan')
+        self.assertRaises(ZeroDivisionError, test, 'sort_keys')
+
+    def test_unsortable_keys(self):
+        with self.assertRaises(TypeError):
+            self.json.encoder.JSONEncoder(sort_keys=True).encode({'a': 1, 1: 'a'})

--- a/tests/cpython/test_speedups.py
+++ b/tests/cpython/test_speedups.py
@@ -1,4 +1,4 @@
-from test.test_json import CTest
+from cpython import CTest
 
 
 class BadBool:

--- a/tests/cpython/test_tool.py
+++ b/tests/cpython/test_tool.py
@@ -1,0 +1,107 @@
+import os
+import sys
+import textwrap
+import unittest
+from subprocess import Popen, PIPE
+from test import support
+from test.support.script_helper import assert_python_ok
+
+
+class TestTool(unittest.TestCase):
+    data = """
+
+        [["blorpie"],[ "whoops" ] , [
+                                 ],\t"d-shtaeou",\r"d-nthiouh",
+        "i-vhbjkhnth", {"nifty":87}, {"morefield" :\tfalse,"field"
+            :"yes"}  ]
+           """
+
+    expect_without_sort_keys = textwrap.dedent("""\
+    [
+        [
+            "blorpie"
+        ],
+        [
+            "whoops"
+        ],
+        [],
+        "d-shtaeou",
+        "d-nthiouh",
+        "i-vhbjkhnth",
+        {
+            "nifty": 87
+        },
+        {
+            "field": "yes",
+            "morefield": false
+        }
+    ]
+    """)
+
+    expect = textwrap.dedent("""\
+    [
+        [
+            "blorpie"
+        ],
+        [
+            "whoops"
+        ],
+        [],
+        "d-shtaeou",
+        "d-nthiouh",
+        "i-vhbjkhnth",
+        {
+            "nifty": 87
+        },
+        {
+            "morefield": false,
+            "field": "yes"
+        }
+    ]
+    """)
+
+    def test_stdin_stdout(self):
+        args = sys.executable, '-m', 'json.tool'
+        with Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE) as proc:
+            out, err = proc.communicate(self.data.encode())
+        self.assertEqual(out.splitlines(), self.expect.encode().splitlines())
+        self.assertEqual(err, b'')
+
+    def _create_infile(self):
+        infile = support.TESTFN
+        with open(infile, "w") as fp:
+            self.addCleanup(os.remove, infile)
+            fp.write(self.data)
+        return infile
+
+    def test_infile_stdout(self):
+        infile = self._create_infile()
+        rc, out, err = assert_python_ok('-m', 'json.tool', infile)
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.splitlines(), self.expect.encode().splitlines())
+        self.assertEqual(err, b'')
+
+    def test_infile_outfile(self):
+        infile = self._create_infile()
+        outfile = support.TESTFN + '.out'
+        rc, out, err = assert_python_ok('-m', 'json.tool', infile, outfile)
+        self.addCleanup(os.remove, outfile)
+        with open(outfile, "r") as fp:
+            self.assertEqual(fp.read(), self.expect)
+        self.assertEqual(rc, 0)
+        self.assertEqual(out, b'')
+        self.assertEqual(err, b'')
+
+    def test_help_flag(self):
+        rc, out, err = assert_python_ok('-m', 'json.tool', '-h')
+        self.assertEqual(rc, 0)
+        self.assertTrue(out.startswith(b'usage: '))
+        self.assertEqual(err, b'')
+
+    def test_sort_keys_flag(self):
+        infile = self._create_infile()
+        rc, out, err = assert_python_ok('-m', 'json.tool', '--sort-keys', infile)
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.splitlines(),
+                         self.expect_without_sort_keys.encode().splitlines())
+        self.assertEqual(err, b'')

--- a/tests/cpython/test_unicode.py
+++ b/tests/cpython/test_unicode.py
@@ -1,0 +1,98 @@
+import codecs
+from collections import OrderedDict
+from test.test_json import PyTest, CTest
+
+
+class TestUnicode:
+    # test_encoding1 and test_encoding2 from 2.x are irrelevant (only str
+    # is supported as input, not bytes).
+
+    def test_encoding3(self):
+        u = '\N{GREEK SMALL LETTER ALPHA}\N{GREEK CAPITAL LETTER OMEGA}'
+        j = self.dumps(u)
+        self.assertEqual(j, '"\\u03b1\\u03a9"')
+
+    def test_encoding4(self):
+        u = '\N{GREEK SMALL LETTER ALPHA}\N{GREEK CAPITAL LETTER OMEGA}'
+        j = self.dumps([u])
+        self.assertEqual(j, '["\\u03b1\\u03a9"]')
+
+    def test_encoding5(self):
+        u = '\N{GREEK SMALL LETTER ALPHA}\N{GREEK CAPITAL LETTER OMEGA}'
+        j = self.dumps(u, ensure_ascii=False)
+        self.assertEqual(j, '"{0}"'.format(u))
+
+    def test_encoding6(self):
+        u = '\N{GREEK SMALL LETTER ALPHA}\N{GREEK CAPITAL LETTER OMEGA}'
+        j = self.dumps([u], ensure_ascii=False)
+        self.assertEqual(j, '["{0}"]'.format(u))
+
+    def test_big_unicode_encode(self):
+        u = '\U0001d120'
+        self.assertEqual(self.dumps(u), '"\\ud834\\udd20"')
+        self.assertEqual(self.dumps(u, ensure_ascii=False), '"\U0001d120"')
+
+    def test_big_unicode_decode(self):
+        u = 'z\U0001d120x'
+        self.assertEqual(self.loads('"' + u + '"'), u)
+        self.assertEqual(self.loads('"z\\ud834\\udd20x"'), u)
+
+    def test_unicode_decode(self):
+        for i in range(0, 0xd7ff):
+            u = chr(i)
+            s = '"\\u{0:04x}"'.format(i)
+            self.assertEqual(self.loads(s), u)
+
+    def test_unicode_preservation(self):
+        self.assertEqual(type(self.loads('""')), str)
+        self.assertEqual(type(self.loads('"a"')), str)
+        self.assertEqual(type(self.loads('["a"]')[0]), str)
+
+    def test_bytes_encode(self):
+        self.assertRaises(TypeError, self.dumps, b"hi")
+        self.assertRaises(TypeError, self.dumps, [b"hi"])
+
+    def test_bytes_decode(self):
+        for encoding, bom in [
+                ('utf-8', codecs.BOM_UTF8),
+                ('utf-16be', codecs.BOM_UTF16_BE),
+                ('utf-16le', codecs.BOM_UTF16_LE),
+                ('utf-32be', codecs.BOM_UTF32_BE),
+                ('utf-32le', codecs.BOM_UTF32_LE),
+            ]:
+            data = ["a\xb5\u20ac\U0001d120"]
+            encoded = self.dumps(data).encode(encoding)
+            self.assertEqual(self.loads(bom + encoded), data)
+            self.assertEqual(self.loads(encoded), data)
+        self.assertRaises(UnicodeDecodeError, self.loads, b'["\x80"]')
+        # RFC-7159 and ECMA-404 extend JSON to allow documents that
+        # consist of only a string, which can present a special case
+        # not covered by the encoding detection patterns specified in
+        # RFC-4627 for utf-16-le (XX 00 XX 00).
+        self.assertEqual(self.loads('"\u2600"'.encode('utf-16-le')),
+                         '\u2600')
+        # Encoding detection for small (<4) bytes objects
+        # is implemented as a special case. RFC-7159 and ECMA-404
+        # allow single codepoint JSON documents which are only two
+        # bytes in utf-16 encodings w/o BOM.
+        self.assertEqual(self.loads(b'5\x00'), 5)
+        self.assertEqual(self.loads(b'\x007'), 7)
+        self.assertEqual(self.loads(b'57'), 57)
+
+    def test_object_pairs_hook_with_unicode(self):
+        s = '{"xkd":1, "kcw":2, "art":3, "hxm":4, "qrt":5, "pad":6, "hoy":7}'
+        p = [("xkd", 1), ("kcw", 2), ("art", 3), ("hxm", 4),
+             ("qrt", 5), ("pad", 6), ("hoy", 7)]
+        self.assertEqual(self.loads(s), eval(s))
+        self.assertEqual(self.loads(s, object_pairs_hook = lambda x: x), p)
+        od = self.loads(s, object_pairs_hook = OrderedDict)
+        self.assertEqual(od, OrderedDict(p))
+        self.assertEqual(type(od), OrderedDict)
+        # the object_pairs_hook takes priority over the object_hook
+        self.assertEqual(self.loads(s, object_pairs_hook = OrderedDict,
+                                    object_hook = lambda x: None),
+                         OrderedDict(p))
+
+
+class TestPyUnicode(TestUnicode, PyTest): pass
+class TestCUnicode(TestUnicode, CTest): pass

--- a/tests/cpython/test_unicode.py
+++ b/tests/cpython/test_unicode.py
@@ -1,6 +1,6 @@
 import codecs
 from collections import OrderedDict
-from test.test_json import PyTest, CTest
+from cpython import PyTest, CTest, RustTest
 
 
 class _TestUnicode:
@@ -96,3 +96,4 @@ class _TestUnicode:
 
 class TestPyUnicode(_TestUnicode, PyTest): pass
 class TestCUnicode(_TestUnicode, CTest): pass
+class TestRustUnicode(_TestUnicode, RustTest): pass

--- a/tests/cpython/test_unicode.py
+++ b/tests/cpython/test_unicode.py
@@ -94,6 +94,6 @@ class _TestUnicode:
                          OrderedDict(p))
 
 
-class TestPyUnicode(_TestUnicode, PyTest): pass
-class TestCUnicode(_TestUnicode, CTest): pass
+# class TestPyUnicode(_TestUnicode, PyTest): pass
+# class TestCUnicode(_TestUnicode, CTest): pass
 class TestRustUnicode(_TestUnicode, RustTest): pass

--- a/tests/cpython/test_unicode.py
+++ b/tests/cpython/test_unicode.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from test.test_json import PyTest, CTest
 
 
-class TestUnicode:
+class _TestUnicode:
     # test_encoding1 and test_encoding2 from 2.x are irrelevant (only str
     # is supported as input, not bytes).
 
@@ -94,5 +94,5 @@ class TestUnicode:
                          OrderedDict(p))
 
 
-class TestPyUnicode(TestUnicode, PyTest): pass
-class TestCUnicode(TestUnicode, CTest): pass
+class TestPyUnicode(_TestUnicode, PyTest): pass
+class TestCUnicode(_TestUnicode, CTest): pass


### PR DESCRIPTION
I've ported [CPython](https://github.com/python/cpython) 3.6.5's test cases for json module to hyperjson. I disable the `test_recursion.py` due to it crash the process. Except the `test_recursion.py`, I get `44 failed, 27 passed` for these test cases. Hopefully, this can help us understand how compatable we are and disscover bugs or some edge cases.

If we discover some behavior we won't implement at all, we better write them done to the docs.