### PR TITLE
Fnv hasher with default capacity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,10 +58,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "hyperjson"
 version = "0.1.0"
 dependencies = [
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pyo3 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -336,6 +342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
 "checksum failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7efb22686e4a466b1ec1a15c2898f91fa9cb340452496dca654032de20ff95b9"
 "checksum failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "946d0e98a50d9831f5d589038d2ca7f8f455b1c21028c0db0e84116a12696426"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ serde_json = "1.0.13"
 failure = "0.1.1"
 serde = "1.0.53"
 serde_derive = "1.0.53"
+fnv = "1.0.6"
 
 [dependencies.pyo3]
 version = "0.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ use pyo3::prelude::*;
 use serde::de::{self, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde::ser::{self, Serialize, SerializeMap, SerializeSeq, Serializer};
 
+const DEFAUL_HASHMAP_CAPACITY: usize = 10;
+
 #[derive(Debug, Fail)]
 pub enum HyperJsonError {
     #[fail(display = "Conversion error: {}", error)]
@@ -540,7 +542,7 @@ impl<'de, 'a> Visitor<'de> for HyperJsonValue<'a> {
     where
         A: MapAccess<'de>,
     {
-        let mut entries = FnvHashMap::default();
+        let mut entries = FnvHashMap::with_capacity_and_hasher(DEFAUL_HASHMAP_CAPACITY, Default::default());
 
         while let Some((key, value)) = map.next_entry_seed(PhantomData::<String>, self)? {
             entries.insert(key, value);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,9 @@ extern crate serde_derive;
 extern crate pyo3;
 extern crate serde_json;
 
-use std::collections::BTreeMap;
+extern crate fnv;
+
+use fnv::FnvHashMap;
 use std::fmt;
 use std::marker::PhantomData;
 
@@ -538,7 +540,7 @@ impl<'de, 'a> Visitor<'de> for HyperJsonValue<'a> {
     where
         A: MapAccess<'de>,
     {
-        let mut entries = BTreeMap::new();
+        let mut entries = FnvHashMap::default();
 
         while let Some((key, value)) = map.next_entry_seed(PhantomData::<String>, self)? {
             entries.insert(key, value);


### PR DESCRIPTION
This PR goes on top of https://github.com/mre/hyperjson/pull/43

Changes:
* Initialize `entites` with default capacity > 0. 

This may safe some extra memory allocations. 

Benchmarks are again slightly contradictional.
Please consider this PR only like an idea. Feel free to reject it if it does not bring any useful improvement