### PR TITLE
Applied several clippy suggestions

### DIFF
--- a/profiling/src/main.rs
+++ b/profiling/src/main.rs
@@ -36,7 +36,10 @@ arg_enum! {
 #[derive(StructOpt, Debug)]
 struct Opt {
     /// Profile to use
-    #[structopt(raw(possible_values = "&Profile::variants()", case_insensitive = "true"))]
+    #[structopt(raw(
+        possible_values = "&Profile::variants()",
+        case_insensitive = "true"
+    ))]
     profile: Profile,
 
     /// Number of profiling iterations

--- a/profiling/src/profiles/booleans.rs
+++ b/profiling/src/profiles/booleans.rs
@@ -26,8 +26,7 @@ pub fn exec(iterations: u64) {
                 None,
                 None,
                 None,
-            )
-            .is_ok()
+            ).is_ok()
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,20 +246,20 @@ pub fn loads_impl(
                     Ok(py_object)
                 }
                 Err(e) => {
-                    return convert_special_floats(py, &string, &parse_int).or_else(|err| {
+                    convert_special_floats(py, &string, &parse_int).or_else(|err| {
                         if e.is_syntax() {
-                            return Err(JSONDecodeError::py_err((
+                            Err(JSONDecodeError::py_err((
                                 format!("Value: {:?}, Error: {:?}", s, err),
                                 string.clone(),
                                 0,
-                            )));
+                            )))
                         } else {
-                            return Err(PyValueError::py_err(format!(
+                            Err(PyValueError::py_err(format!(
                                 "Value: {:?}, Error: {:?}",
                                 s, e
-                            )));
+                            )))
                         }
-                    });
+                    })
                 }
             }
         }
@@ -280,10 +280,10 @@ pub fn loads_impl(
                     Ok(py_object)
                 }
                 Err(e) => {
-                    return Err(PyTypeError::py_err(format!(
+                    Err(PyTypeError::py_err(format!(
                         "the JSON object must be str, bytes or bytearray, got: {:?}",
                         e
-                    )));
+                    )))
                 }
             }
         }


### PR DESCRIPTION
This PR tries to reduce the warning-noise when `cargo clippy` is applied.

The most common warning was about passing arguments by value instead of passing by reference:

```text
warning: this argument is passed by value, but not consumed in the function body
   --> src/lib.rs:228:8
    |
228 |     s: PyObject,
    |        ^^^^^^^^ help: consider taking a reference instead: `&PyObject`
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#needless_pass_by_value
```

Some of the warnings I managed to resolve, but for functions annotated with `#[pyfunction]` the simple usage of `&Option<>` introduces an error:
```text
error[E0277]: the trait bound `pyo3::PyObject: pyo3::PyTypeInfo` is not satisfied                                                                                                             
   --> src/lib.rs:153:1                                                                                                                                                                       
    |                                                                                                                                                                                         
153 | #[pyfunction]                                                                                                                                                                           
    | ^^^^^^^^^^^^^ the trait `pyo3::PyTypeInfo` is not implemented for `pyo3::PyObject`                                                                                                      
    |                                                                                                                                                                                         
    = note: required because of the requirements on the impl of `pyo3::PyTryFrom` for `pyo3::PyObject`                                                                                        
    = note: required because of the requirements on the impl of `pyo3::FromPyObject<'_>` for `&pyo3::PyObject`                                                                                
    = note: required by `pyo3::ObjectProtocol::extract`   
```
The way to resolve the error could be the usage the [`PyObjectRef`](https://docs.rs/pyo3/0.5.0/pyo3/types/struct.PyObjectRef.html) and also the usage of `#[pyfn()]` instead of `#[pyfunction]` (actually could not find `#[pyfunction] ` in the `0.5.0` documentation - could it be deprecated?), but that would introduce the API breakage, so I left it for now.

The result changes are somewhat chaotic, so feel free to close 
