### PR TITLE
Use release build for bench and test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ nightly: ## Set rust compiler to nightly version
 
 .PHONY: install
 install: nightly dev-packages ## Install hyperjson module into current virtualenv
-	pipenv run maturin develop
+	pipenv run maturin develop --release
 
 .PHONY: publish
 publish: ## Publish crate on Pypi


### PR DESCRIPTION
Oversight from other PR - `maturin develop` respects the --release flag (and needs it if benchmarks are gonna be meaningful)