### PR TITLE
Fix pipenv vs poetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           toolchain: nightly
           override: true
+          components: rustfmt, clippy
 
       - name: Lint with rustfmt
         uses: actions-rs/cargo@v1
@@ -66,7 +67,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install poetry
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+          echo "::add-path::${HOME}/.poetry/bin"
           poetry install
 
       - name: Install latest nightly

--- a/README.md
+++ b/README.md
@@ -93,10 +93,11 @@ Just pick one of the open tickets. We can provide mentorship if you like. :smile
 
 ## Developer guide
 
-This project uses [pipenv](https://docs.pipenv.org/) for managing the development environment. If you don't have it installed, run
+This project uses [poetry](https://python-poetry.org/docs/) for managing the development environment. If you don't have it installed, run
 
 ```
-pip install poetry
+curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+export PATH="$HOME/.poetry/bin:$PATH"
 ```
 
 The project requires the `nightly` version of Rust.

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -8,10 +8,11 @@ main() {
     export PATH="$HOME/.cargo/bin:$PATH"
     which rustc
     rustc --version
-    pip install pipenv
+    curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+    source ~/.poetry/env
     cargo install maturin
     make install
-    pipenv graph
+    poetry show --tree
 }
 
 main


### PR DESCRIPTION
* update README.md because this project is not using pipenv but poetry
* alter poetry installation because `pip install poetry` can mess up
  currently installed packages.
  (see https://python-poetry.org/docs/#installing-with-pip)
* fix install.sh script (pipenv -> poetry)
* update github actions to install poetry properly