### PR TITLE
Fixup CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,17 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
-          echo "::add-path::${HOME}/.poetry/bin"
+
+      - name: Add poetry to path
+        if:  matrix.os != 'windows-latest'
+        run: echo "${HOME}/.poetry/bin" >> $GITHUB_PATH
+      
+      - name: Add poetry to path
+        if:  matrix.os == 'windows-latest'
+        run: echo "${HOME}/.poetry/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Install package deps
+        run: | 
           poetry install
 
       - name: Install latest nightly


### PR DESCRIPTION
Github deprecated the `::add_path` command sometime in October which is causing the CI to fail, adding platform specific steps for modifying the PATH should fix this (at least [it did in my poetry/py03 project](https://github.com/wseaton/sqloxide/compare/7ecbb01..ed41af9)).

Relevant error:
```sh
The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ 
```